### PR TITLE
Include User-Agent Header in Calls to ONCat API

### DIFF
--- a/scripts/finddata
+++ b/scripts/finddata
@@ -7,9 +7,9 @@ import os
 import re
 import sys
 try:
-    from urllib import urlopen
+    from urllib2 import Request, urlopen
 except ImportError:
-    from urllib.request import urlopen
+    from urllib.request import Request, urlopen
 from finddata import __version__
 
 BASE_URL = 'https://oncat.ornl.gov/'
@@ -52,6 +52,8 @@ def procNumbers(numbers):
 
 def getJson(endpoint):
     url = BASE_URL + endpoint
+    req = Request(url)
+    req.add_header('User-Agent', 'Finddata ' + __version__)
     handle = urlopen(url)
     doc = handle.read().decode()
     logging.debug("DOC:" + doc)

--- a/scripts/finddata
+++ b/scripts/finddata
@@ -58,7 +58,7 @@ def getJson(endpoint):
     url = BASE_URL + endpoint
     req = Request(url)
     req.add_header('User-Agent', 'Finddata ' + __version__)
-    handle = urlopen(url)
+    handle = urlopen(req)
     if handle.getcode() != 200:
         raise RuntimeError('{} returned code={}'.format(url, handle.getcode()))
     doc = handle.read().decode()

--- a/scripts/finddata
+++ b/scripts/finddata
@@ -57,7 +57,7 @@ def procNumbers(numbers):
 def getJson(endpoint):
     url = BASE_URL + endpoint
     req = Request(url)
-    req.add_header('User-Agent', 'Finddata ' + __version__)
+    req.add_header('User-Agent', 'Finddata/' + __version__)
     handle = urlopen(req)
     if handle.getcode() != 200:
         raise RuntimeError('{} returned code={}'.format(url, handle.getcode()))


### PR DESCRIPTION
This is so that we may more easily track `finddata` usage in the ONCat logs.  The fact that we're not authenticating first means this is pretty difficult to track, otherwise.

Note that we're doing something similar for Mantid, here:

https://github.com/mantidproject/mantid/blob/master/Framework/Kernel/src/InternetHelper.cpp#L147

Apologies this took 4 commits ... I can squash and resubmit if you care about how the history looks.