### PR TITLE
Update API call with the correct order of arguments

### DIFF
--- a/scripts/finddata
+++ b/scripts/finddata
@@ -119,7 +119,7 @@ def getRunsInProp(facility, instrument, proposal):
         '&instrument=%s'
         '&projection=indexed'
     )
-    doc = getJson(endpoint % (facility, proposal, instrument))
+    doc = getJson(endpoint % (proposal, facility, instrument))
 
     return doc['indexed']['run_number']['ranges']
 


### PR DESCRIPTION
**Description**
Changed the order of arguments for the correct API call. 

**Testing**
tested using `finddata NOM --listruns IPTS-28579` also tested `finddata CORELLI 295331` to ensure that it is still working.

Fixes #8 