### PR TITLE
Log error return code and throw exception

### DIFF
--- a/finddata/publish_plot.py
+++ b/finddata/publish_plot.py
@@ -106,14 +106,18 @@ def publish_plot(instrument, run_number, files, config=None):
 
     import requests
     if config.publisher_certificate:
-        request = requests.post(url, data={'username': config.publisher_username,
+        response = requests.post(url, data={'username': config.publisher_username,
                                            'password': config.publisher_password},
                                 files=files, cert=config.publisher_certificate)
     else:
-        request = requests.post(url, data={'username': config.publisher_username,
+        response = requests.post(url, data={'username': config.publisher_username,
                                            'password': config.publisher_password},
                                 files=files, verify=False)
-    return request
+
+    if response.status_code != requests.codes.ok:
+        logging.error("Publish plot failed with return code: %d", response.status_code)
+        response.raise_for_status()  # throw requests.HTTPError error with details
+    return response
 
 
 def plot1d(run_number, data_list, data_names=None, x_title='', y_title='',


### PR DESCRIPTION
To aid in keeping client code "simple" and aid in debugging issues in monitor, add a log message when the return code of the request is not ok (200) and raise an `HTTPError` for the client to deal with. 

Since the library being used is `requests` and the return variable was `request`, I renamed the variable to `response` to make the code a little easier to read.

For reference:
* [requests library quickstart](https://docs.python-requests.org/en/latest/user/quickstart/#more-complicated-post-requests)
* [docs for HTTPError](https://requests.readthedocs.io/en/latest/api/#requests.HTTPError)