### PR TITLE
Drop python2 support and add rpmbuild.sh

### DIFF
--- a/finddata.spec
+++ b/finddata.spec
@@ -4,7 +4,7 @@
 
 Summary: %{summary}
 Name: python-%{srcname}
-Version: 0.8.3
+Version: 0.9.0
 Release: %{release}%{?dist}
 Source0: https://github.com/peterfpeterson/finddata/archive/v%{version}.tar.gz
 License: MIT
@@ -18,23 +18,9 @@ Url: https://github.com/peterfpeterson/finddata
 %description
 Finddata uses ONCat to locate the full path of files on the NScD clusters.
 
-%package -n %{srcname}
-Summary:  %{summary}
-Requires: python2
-Requires: python2-plotly
-Requires: python2-pyoncat
-%{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
-
-BuildRequires: python2-devel
-BuildRequires: python2-setuptools
-
-%description -n %{srcname}
-Finddata uses ONCat to locate the full path of files on the NScD clusters.
-
 %package -n python%{python3_pkgversion}-%{srcname}
 Summary:  %{summary}
 Requires: python%{python3_pkgversion}
-Requires: python%{python3_pkgversion}-plotly
 Requires: python%{python3_pkgversion}-pyoncat
 Requires: bash
 Requires: bash-completion
@@ -51,11 +37,9 @@ Finddata uses ONCat to locate the full path of files on the NScD clusters.
 %setup -n %{srcname}-%{version} -n %{srcname}-%{version}
 
 %build
-%py2_build
 %py3_build
 
 %install
-%py2_install
 %py3_install
 
 # testing is somehow broken, but the package did work
@@ -66,11 +50,6 @@ Finddata uses ONCat to locate the full path of files on the NScD clusters.
 
 %clean
 rm -rf $RPM_BUILD_ROOT
-
-%files -n %{srcname}
-%doc README
-%license LICENSE.txt
-%{python2_sitelib}/*
 
 %files -n python%{python3_pkgversion}-%{srcname}
 %doc README

--- a/finddata.spec
+++ b/finddata.spec
@@ -4,7 +4,7 @@
 
 Summary: %{summary}
 Name: python-%{srcname}
-Version: 0.9.0
+Version: 0.9.1
 Release: %{release}%{?dist}
 Source0: https://github.com/peterfpeterson/finddata/archive/v%{version}.tar.gz
 License: MIT
@@ -21,7 +21,7 @@ Finddata uses ONCat to locate the full path of files on the NScD clusters.
 %package -n python%{python3_pkgversion}-%{srcname}
 Summary:  %{summary}
 Requires: python%{python3_pkgversion}
-Requires: python%{python3_pkgversion}-pyoncat
+Requires: python%{python3_pkgversion}-urllib3
 Requires: bash
 Requires: bash-completion
 Requires: python%{python3_pkgversion}-argcomplete

--- a/finddata/publish_plot.py
+++ b/finddata/publish_plot.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import (absolute_import, division, print_function, unicode_literals)
 import json
 import logging
 import os

--- a/rpmbuild.sh
+++ b/rpmbuild.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# get the version from the spec file
+SPECFILE="$(dirname "$(realpath "$0")")/finddata.spec"
+echo "Finding version from ${SPECFILE}"
+
+VERSION="$(grep Version "${SPECFILE}" | awk '{print $2}')"
+if [ -z "${VERSION}" ]; then
+    echo "Failed to determine the version from ${SPECFILE}"
+    exit 127
+fi
+echo "Version is ${VERSION}"
+
+# create the tarball
+TARBALL="finddata-v${VERSION}.tar.gz"
+echo "creating tarball ${TARBALL}"
+git archive --format=tar.gz HEAD --prefix="finddata-${VERSION}/" -o "${TARBALL}"
+mkdir -p "${HOME}"/rpmbuild/SOURCES
+cp "${TARBALL}" "${HOME}/rpmbuild/SOURCES/v${VERSION}.tar.gz"
+
+# build the rpm and give instructions
+echo "building the rpm"
+rpmbuild -ba finddata.spec || exit 127
+
+echo "========================================"
+echo "Successfully built rpm. To manually inspect package run"
+echo "rpm -qilRp ~/rpmbuild/RPMS/noarch/python3-finddata-${VERSION}-1.el7.noarch.rpm"

--- a/rpmbuild.sh
+++ b/rpmbuild.sh
@@ -21,6 +21,7 @@ cp "${TARBALL}" "${HOME}/rpmbuild/SOURCES/v${VERSION}.tar.gz"
 echo "building the rpm"
 rpmbuild -ba finddata.spec || exit 127
 
+DIST=$(rpm --eval %{?dist})
 echo "========================================"
 echo "Successfully built rpm. To manually inspect package run"
-echo "rpm -qilRp ~/rpmbuild/RPMS/noarch/python3-finddata-${VERSION}-1.el7.noarch.rpm"
+echo "rpm -qilRp ~/rpmbuild/RPMS/noarch/python3-finddata-${VERSION}-1${DIST}.noarch.rpm"

--- a/scripts/finddata
+++ b/scripts/finddata
@@ -3,10 +3,7 @@ import json
 import logging
 import os
 import sys
-try:
-    from urllib2 import Request, urlopen
-except ImportError:
-    from urllib.request import Request, urlopen
+from urllib3 import PoolManager
 from finddata import __version__
 
 BASE_URL = 'https://oncat.ornl.gov/'
@@ -56,15 +53,16 @@ def procNumbers(numbers):
 
 
 def getJson(endpoint):
+    # make a request
     url = BASE_URL + endpoint
-    req = Request(url)
-    req.add_header('User-Agent', 'Finddata/' + __version__)
-    handle = urlopen(req)
-    if handle.getcode() != 200:
-        raise RuntimeError('{} returned code={}'.format(url, handle.getcode()))
-    doc = handle.read().decode()
-    logging.debug("DOC:" + doc)
+    http = PoolManager()
+    req = http.request("GET", url, headers={'User-Agent': f'Finddata/{__version__}'})
+    if req.status != 200:
+        raise RuntimeError('{} returned code={}'.format(url, req.status))
 
+    # convert the result into json
+    doc = req.data.decode()
+    logging.debug("DOC:" + doc)
     return json.loads(doc)
 
 

--- a/scripts/finddata
+++ b/scripts/finddata
@@ -1,7 +1,4 @@
 #!/usr/bin/env python
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import json
 import logging
 import os


### PR DESCRIPTION
This removes python2 support and migrates information to build on rhel9. Part of this is changing the requirements from pyoncat (unused) to urllib3.